### PR TITLE
fix environment variable name

### DIFF
--- a/keyme/cli/fetch_creds.py
+++ b/keyme/cli/fetch_creds.py
@@ -177,6 +177,6 @@ def login(config, mfa, username, password, idp, sp, principal, role, region, env
         {}
     )
 
-    click.echo('export AWS_ACCESS_KEY=\'' + k['aws']['access_key'].encode('utf-8') + '\'')
+    click.echo('export AWS_ACCESS_KEY_ID=\'' + k['aws']['access_key'].encode('utf-8') + '\'')
     click.echo('export AWS_SECRET_ACCESS_KEY=\'' + k['aws']['secret_key'].encode('utf-8') +'\'')
     click.echo('export AWS_SESSION_TOKEN=\'' + k['aws']['session_token'].encode('utf-8') + '\'')


### PR DESCRIPTION
According to the documentation the variable name should be AWS_ACCESS_KEY_ID:

http://docs.aws.amazon.com/cli/latest/topic/config-vars.html