### PR TITLE
Python 3 Compatibility

### DIFF
--- a/keyme/__init__.py
+++ b/keyme/__init__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 from bs4 import BeautifulSoup
 import base64
 import boto3
@@ -35,7 +37,7 @@ class KeyMe:
         self.google_accounts_url = "https://accounts.google.com/o/saml2/initsso?idpid=%s&spid=%s&forceauthn=false" % (self.idp,
                                                                                                                       self.sp)
         if kwargs:
-            raise ValueError, ("Extraneous keys passed: %s" % kwargs.keys())
+            raise ValueError("Extraneous keys passed: %s" % kwargs.keys())
 
     def key(self):
         """Return a key object"""
@@ -133,7 +135,7 @@ class KeyMe:
             try:
                 raise ValueError('Wrong Password or Captcha Required. Manually Login to remove this.')
             except ValueError as e:
-                print e
+                print(e)
                 sys.exit(1)
 
         session.headers['Referrer'] = google_session.url
@@ -174,9 +176,9 @@ class KeyMe:
 
         try:
             if not saml_element:
-                raise StandardError, 'Could not get a SAML reponse, check credentials'
-        except StandardError as e:
-            print e
+                raise Exception('Could not get a SAML reponse, check credentials')
+        except Exception as e:
+            print(e)
             sys.exit(1)
 
         return saml_element

--- a/keyme/cli/fetch_creds.py
+++ b/keyme/cli/fetch_creds.py
@@ -21,7 +21,7 @@ class Config(dict):
             pass
 
     def save(self):
-    	self.config.ensure()
+        self.config.ensure()
         with self.config.open('w') as f: # B
             f.write(json.dumps(self))
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ keyme and fetch_creds -- Tools for interacting with GOOGLE SAML SSO and AWS SAML
 
 from setuptools import find_packages, setup
 
-dependencies = ['click', 'boto3', 'bs4', 'beautifulsoup', 'requests', 'py']
+dependencies = ['click', 'boto3', 'beautifulsoup4', 'requests', 'py']
 
 setup(name='keyme',
       version='0.7.0',


### PR DESCRIPTION
Adds compatibility for Python 3. The unused beatifulsoup 3 dependency has been removed and the dummy bs4 dependency replaced with the official repo name. StandardError has been replaced by Exception, which is the compatible base exception across all Python versions (see http://python3porting.com/differences.html#standarderror) for porting details on that. The future print function has been imported and all print statements are now function calls instead of statements.