### PR TITLE
Remove non-existant input check

### DIFF
--- a/keyme/__init__.py
+++ b/keyme/__init__.py
@@ -73,7 +73,6 @@ class KeyMe:
 
         # Collect information from the page source
         decoded = BeautifulSoup(google_session.text, 'html.parser')
-        galx = decoded.find('input', {'name': 'GALX'}).get('value')
         gxf = decoded.find('input', {'name': 'gxf'}).get('value')
         cont = decoded.find('input', {'name': 'continue'}).get('value')
         page = decoded.find('input', {'name': 'Page'}).get('value')
@@ -83,7 +82,6 @@ class KeyMe:
         # Setup the payload
         payload = {
             'Page': page,
-            'GALX': galx,
             'gxf': gxf,
             'continue': cont,
             'ltmpl': 'popup',

--- a/keyme/cli/fetch_creds.py
+++ b/keyme/cli/fetch_creds.py
@@ -177,6 +177,6 @@ def login(config, mfa, username, password, idp, sp, principal, role, region, env
         {}
     )
 
-    click.echo('export AWS_ACCESS_KEY_ID=\'' + k['aws']['access_key'].encode('utf-8') + '\'')
-    click.echo('export AWS_SECRET_ACCESS_KEY=\'' + k['aws']['secret_key'].encode('utf-8') +'\'')
-    click.echo('export AWS_SESSION_TOKEN=\'' + k['aws']['session_token'].encode('utf-8') + '\'')
+    click.echo('export AWS_ACCESS_KEY_ID=\'' + k['aws']['access_key'] + '\'')
+    click.echo('export AWS_SECRET_ACCESS_KEY=\'' + k['aws']['secret_key'] +'\'')
+    click.echo('export AWS_SESSION_TOKEN=\'' + k['aws']['session_token'] + '\'')

--- a/keyme/cli/fetch_creds.py
+++ b/keyme/cli/fetch_creds.py
@@ -177,6 +177,7 @@ def login(config, mfa, username, password, idp, sp, principal, role, region, env
         {}
     )
 
-    click.echo('export AWS_ACCESS_KEY_ID=\'' + k['aws']['access_key'] + '\'')
-    click.echo('export AWS_SECRET_ACCESS_KEY=\'' + k['aws']['secret_key'] +'\'')
-    click.echo('export AWS_SESSION_TOKEN=\'' + k['aws']['session_token'] + '\'')
+    aws = k['aws']
+    click.echo("export AWS_ACCESS_KEY_ID=\'%(access_key)s\'" % aws)
+    click.echo("export AWS_SECRET_ACCESS_KEY=\'%(secret_key)s\'" % aws)
+    click.echo("export AWS_SESSION_TOKEN=\'%(session_token)s\'" % aws)


### PR DESCRIPTION
The GALX input no longer exists in the HTML returned from Google. I removed it and it still works fine (not tested using 2FA).

An exception was being thrown on the ```.encode``` call so I removed that (and switched to interpolation). Still works.