### PR TITLE
Config Parsing

### DIFF
--- a/keyme/test/test_writer.py
+++ b/keyme/test/test_writer.py
@@ -1,0 +1,88 @@
+import unittest
+
+from mock import patch
+from keyme import writer
+
+
+class TestWriter(unittest.TestCase):
+    """Test suite for the writer module"""
+
+    @patch('builtins.open')
+    @patch('os.path.exists')
+    @patch('keyme.writer.create_backup')
+    @patch('keyme.writer.ConfigParser.write')
+    @patch('keyme.writer.ConfigParser.read')
+    def test_write_credentials_file(
+            self,
+            read,
+            write,
+            create_backup,
+            exists,
+            builtins_open
+    ):
+        """Should write a credentials file with the specified info"""
+
+        exists.return_value = True
+
+        result = writer.write_credentials_file(
+            profile_name='TEST',
+            access_key='ACCESS_KEY',
+            secret_key='SECRET_KEY',
+            session_token='SESSION_TOKEN'
+        )
+
+        self.assertEqual(1, read.call_count)
+        self.assertEqual(1, write.call_count)
+        self.assertEqual(1, create_backup.call_count)
+        self.assertIn('TEST', result)
+
+    @patch('builtins.open')
+    @patch('os.path.exists')
+    @patch('keyme.writer.create_backup')
+    @patch('keyme.writer.ConfigParser.write')
+    @patch('keyme.writer.ConfigParser.read')
+    def test_write_config_file(
+            self,
+            read,
+            write,
+            create_backup,
+            exists,
+            builtins_open
+    ):
+        """Should write a config file with the specified info"""
+
+        exists.return_value = True
+
+        result = writer.write_config_file(profile_name='TEST')
+
+        self.assertEqual(1, read.call_count)
+        self.assertEqual(1, write.call_count)
+        self.assertEqual(1, create_backup.call_count)
+        self.assertIn('profile TEST', result)
+
+    @patch('shutil.copy2')
+    @patch('os.remove')
+    @patch('os.path.exists')
+    def test_create_backup(self, exists, remove, copy):
+        """Should create a backup copy of the specified file"""
+
+        exists.return_value = True
+
+        path = 'fake'
+        backup_path = 'fake.keyme.backup'
+        result = writer.create_backup(path)
+        self.assertTrue(result)
+        self.assertEqual(1, remove.call_count)
+        self.assertEqual(remove.call_args[0][0], backup_path)
+        self.assertEqual(1, copy.call_count)
+        self.assertEqual(copy.call_args[0][0], path)
+        self.assertEqual(copy.call_args[0][1], backup_path)
+
+    @patch('os.path.exists')
+    def test_create_backup_error(self, exists):
+        """Should fail to create a backup copy of the specified file"""
+
+        exists.side_effect = IOError('FAKE')
+
+        result = writer.create_backup('fake-path')
+        self.assertFalse(result)

--- a/keyme/writer.py
+++ b/keyme/writer.py
@@ -1,0 +1,113 @@
+import os
+import shutil
+
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+
+DEFAULT_REGION = 'us-east-1'
+DEFAULT_OUTPUT_TYPE = 'json'
+
+
+def create_backup(source_path):
+    """
+    Creates a backup copy of the specified file in the same location but with
+    a backup extension.
+    """
+
+    backup_path = '{}.keyme.backup'.format(source_path)
+    try:
+        if os.path.exists(backup_path):
+            os.remove(backup_path)
+        shutil.copy2(source_path, backup_path)
+        return True
+    except Exception:
+        return False
+
+
+def write_credentials_file(profile_name, access_key, secret_key, session_token):
+    """
+    Writes the specified AWS credentials to the standard aws credentials
+    file in the user's home directory.
+
+    :param profile_name:
+        The name of the profile for which the credentials will be written.
+    :param access_key:
+        The "aws_access_key_id" value for the specified profile.
+    :param secret_key:
+        The "aws_secret_access_key" value for the specified profile.
+    :param session_token:
+        The "aws_session_token" value for the specified profile.
+    :return:
+        A dictionary representation of the contents of the config file after
+        it has been modified by this function.
+    """
+
+    credentials_path = os.path.expanduser('~/.aws/credentials')
+    credentials = ConfigParser()
+
+    if os.path.exists(credentials_path):
+        credentials.read(credentials_path)
+
+    credentials[profile_name] = dict(
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        aws_session_token=session_token
+    )
+
+    create_backup(credentials_path)
+    with open(credentials_path, 'w') as fp:
+        credentials.write(fp)
+
+    return dict(credentials.items())
+
+
+def write_config_file(
+        profile_name,
+        default_region=DEFAULT_REGION,
+        output_type=DEFAULT_OUTPUT_TYPE,
+        enable_s3v4=False
+):
+    """
+    Write an AWS config file for the specified profile, which includes
+    information about region, output type and other session configuration
+    data.
+
+    :param profile_name:
+        The name of the profile for which the config settings will be written.
+    :param default_region:
+        The default AWS region for the profile.
+    :param output_type:
+        The default data type returned by console commands for this profile.
+    :param enable_s3v4:
+        Whether or not to enable signature version 4 when interacting with
+        S3 data encrypted by KMS.
+    :return:
+        A dictionary representation of the contents of the config file after
+        it has been modified by this function.
+    """
+
+    configs_path = os.path.expanduser('~/.aws/config')
+    configs = ConfigParser()
+
+    if os.path.exists(configs_path):
+        configs.read(configs_path)
+
+    profile_key = 'profile {}'.format(profile_name)
+    if profile_key not in configs:
+        configs[profile_key] = {}
+    config_data = configs[profile_key]
+    config_data['region'] = default_region or DEFAULT_REGION
+    config_data['output'] = output_type or DEFAULT_OUTPUT_TYPE
+
+    if enable_s3v4:
+        config_data['s3'] = '\nsignature_version = s3v4'
+    elif 's3' in config_data:
+        del config_data['s3']
+
+    create_backup(configs_path)
+    with open(configs_path, 'w') as fp:
+        configs.write(fp)
+
+    return dict(configs.items())

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,33 @@
 """
-keyme and fetch_creds -- Tools for interacting with GOOGLE SAML SSO and AWS SAML with STS.
+keyme and fetch_creds -- Tools for interacting with GOOGLE SAML SSO and AWS
+SAML with STS.
 """
 
 from setuptools import find_packages, setup
 
-dependencies = ['click', 'boto3', 'beautifulsoup4', 'requests', 'py']
+dependencies = [
+    'click',
+    'boto3',
+    'beautifulsoup4',
+    'requests',
+    'py',
+    'six'
+]
 
 setup(name='keyme',
       version='0.7.2',
       description='Google SAML STS login library',
-      long_description='This tool allows you to login into AWS using Google SAML Apps as part of Google For Work',
+      long_description=(
+          'This tool allows you to login into AWS using Google SAML Apps as '
+          'part of Google For Work'
+      ),
       url='http://github.com/wheniwork/keyme',
       author='Richard Genthner',
       author_email='richard.genthner@wheniwork.com',
       packages=find_packages(),
       include_package_data=True,
       install_requires=dependencies,
+      tests_require=['pytest', 'mock'],
       license='MIT',
       entry_points = '''
         [console_scripts]


### PR DESCRIPTION
Refactor JSON environment storage to use standard library ConfigParser class for init-styled configuration storage. The environmental data is now stored in an `~/.aws/keyme` file that uses the same data storage format at the AWS credential and config files .

Add credentials and config AWS profile writing using ConfigParser class. Saving to profiles is enabled by the new --save flag in the login command. Save actions will create backup files for the config and credentials files to avoid accidental data corruption should a write process fail for some unknown reason.

Include a new init and login flag for storing s3 signature version 4 settings when writing to AWS config
files, which is needed for profiles using encryption in S3 storage. Enabling this setting has been added to the init command prompts and is stored in keyme environments, but it can also be enabled by flag in the login command.

Remove the username from being stored in the keyme environment. That must now be specified in the login command. Also, update the login command so users are queried for username, password and MFA in that order.