### PR TITLE
ConfigParser Compatibility

### DIFF
--- a/keyme/__init__.py
+++ b/keyme/__init__.py
@@ -207,7 +207,7 @@ class KeyMe:
         parsed = BeautifulSoup(self.session.text, 'html.parser')
         saml_element = (
             parsed
-            .find('input', {'name':'SAMLResponse'})
+            .find('input', {'name': 'SAMLResponse'})
             .get('value')
         )
 


### PR DESCRIPTION
Improve compatibility for ConfigParser usage for both Python 2 and 3.
Fix issue with rejected default profile names due to ConfigParser
default compatibility.