### PR TITLE
Fix for setting a custom expiration duration

### DIFF
--- a/keyme/__init__.py
+++ b/keyme/__init__.py
@@ -31,7 +31,7 @@ class KeyMe:
         self.idp = kwargs.pop('idp')
         self.sp = kwargs.pop('sp')
         if kwargs.get('duration_seconds'):
-            self.timeout = kwargs.pop('duration_seconds')
+            self.duration_seconds = kwargs.pop('duration_seconds')
         else:
             self.duration_seconds = 3600
 


### PR DESCRIPTION
Currently if you try to set duration_seconds, the script will crash, this makes sure duration_seconds is set with the args given.  